### PR TITLE
To stop immediately the flow

### DIFF
--- a/flow_local_actions/GetOracleSSNViaAWS/force-app/main/default/aura/getOracleSSNViaAWS/getOracleSSNViaAWS.cmp
+++ b/flow_local_actions/GetOracleSSNViaAWS/force-app/main/default/aura/getOracleSSNViaAWS/getOracleSSNViaAWS.cmp
@@ -10,5 +10,4 @@
 <aura:component implements="lightning:availableForFlowActions">
 	<aura:attribute name="userId" type="String" required="true"/>
 	<aura:attribute name="ssn" type="String"/>
-  	<aura:attribute name="errorMsg" type="String"/>
 </aura:component>

--- a/flow_local_actions/GetOracleSSNViaAWS/force-app/main/default/aura/getOracleSSNViaAWS/getOracleSSNViaAWSController.js
+++ b/flow_local_actions/GetOracleSSNViaAWS/force-app/main/default/aura/getOracleSSNViaAWS/getOracleSSNViaAWSController.js
@@ -10,8 +10,6 @@
       			cancelToken = event.getParam("arguments").cancelToken;
     		return helper.fetchSSN(userId, cancelToken).then($A.getCallback(function(result) {
         		component.set("v.ssn", result);
-      		})).catch($A.getCallback(function(error) {
-        		component.set("v.errorMsg", error && error.message);
-    		}));
+      		}));
 	}
 })


### PR DESCRIPTION
And not let the user handle this, based on cmp possible errors.
@amagnier-sfdc 